### PR TITLE
fix: use event name instead of type for sync xml serialization

### DIFF
--- a/src/ParcelRegistry.Projections.Legacy/ParcelSyndication/ParcelSyndicationExtensions.cs
+++ b/src/ParcelRegistry.Projections.Legacy/ParcelSyndication/ParcelSyndicationExtensions.cs
@@ -33,7 +33,7 @@ namespace ParcelRegistry.Projections.Legacy.ParcelSyndication
                 applyEventInfoOn);
 
             newParcelSyndicationItem.ApplyProvenance(provenance);
-            newParcelSyndicationItem.SetEventData(message.Message);
+            newParcelSyndicationItem.SetEventData(message.Message, message.EventName);
 
             await context
                 .ParcelSyndication
@@ -67,8 +67,8 @@ namespace ParcelRegistry.Projections.Legacy.ParcelSyndication
             item.Reason = provenance.Reason;
         }
 
-        public static void SetEventData<T>(this ParcelSyndicationItem syndicationItem, T message)
-            => syndicationItem.EventDataAsXml = message.ToXml(message.GetType().Name).ToString(SaveOptions.DisableFormatting);
+        public static void SetEventData<T>(this ParcelSyndicationItem syndicationItem, T message, string eventName)
+            => syndicationItem.EventDataAsXml = message.ToXml(eventName).ToString(SaveOptions.DisableFormatting);
 
         private static ProjectionItemNotFoundException<ParcelSyndicationProjections> DatabaseItemNotFound(Guid parcelId)
             => new ProjectionItemNotFoundException<ParcelSyndicationProjections>(parcelId.ToString("D"));

--- a/src/ParcelRegistry.Projections.Legacy/ParcelSyndication/ParcelSyndicationProjections.cs
+++ b/src/ParcelRegistry.Projections.Legacy/ParcelSyndication/ParcelSyndicationProjections.cs
@@ -26,7 +26,7 @@ namespace ParcelRegistry.Projections.Legacy.ParcelSyndication
                 };
 
                 parcelSyndicationItem.ApplyProvenance(message.Message.Provenance);
-                parcelSyndicationItem.SetEventData(message.Message);
+                parcelSyndicationItem.SetEventData(message.Message, message.EventName);
 
                 await context
                     .ParcelSyndication


### PR DESCRIPTION
no rebuild needed